### PR TITLE
hyperdeck.format fix context scoping

### DIFF
--- a/src/hyperdeck/hyperdeck.js
+++ b/src/hyperdeck/hyperdeck.js
@@ -62,7 +62,7 @@ var Hyperdeck = function(config) {
   };
 
   this.format = function(format){
-    return this.makeRequest('format: prepare: ' + format).then(function(response){
+    return this.makeRequest('format: prepare: ' + format).then((response)=>{
       if (response.code !== 216 || response.text !== 'format ready' || !response.rawData) {
         throw new Error('Unexpected response.');
       }


### PR DESCRIPTION
```this``` inside a then was not scoped correctly.